### PR TITLE
Add basic-snap example using command args

### DIFF
--- a/basic-snap/snap/snapcraft.yaml
+++ b/basic-snap/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ apps:
   basic-snap:
     command: basic.sh
   hello:
-    command: hello.sh
+    command: hello.sh Hello world
   hi:
     command: d1/d2/hi.sh
 

--- a/basic-snap/src2/hello.sh
+++ b/basic-snap/src2/hello.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-echo "basic-snap, hello is running."
+echo "basic-snap, hello says '$@'."
+echo "Received $# arg(s)."


### PR DESCRIPTION
I added an example of passing arguments to a command via the snapcraft.yaml. I happened to notice it being used in the snappy-debug snapcraft.yaml, otherwise, I wouldn't have even thought to try passing arguments. Incidentally, I also ran into some interesting behavior. It seems like the arguments that can be passed through the snapcraft.yaml have to adhere to this regex: `^[A-Za-z0-9/. _#:$-]*$`. Which, as far as a I can tell, means you can't quote arguments, or escape characters (like spaces), so something like `command: hello.sh "Hello, world!"` is triply illegal.

Also, we should consider adding an example like is given in the snappy-debug snapcraft.yaml, where two separate apps point to the same command:

```yaml
...
apps:
  snappy-debug:
    command: bin/snappy-security-scanlog --follow --recommend --only-new
    plugs: [log-observe, system-observe]
  scanlog:
    command: bin/snappy-security-scanlog
    plugs: [log-observe, system-observe]
...
```

I think this really sends home the idea that parts and apps are decoupled.

